### PR TITLE
Implement simple non-empty verbatim bound

### DIFF
--- a/allocative/src/allocative_trait.rs
+++ b/allocative/src/allocative_trait.rs
@@ -25,13 +25,14 @@ use crate::Visitor;
 /// }
 /// ```
 ///
-/// Proc macro supports two attributes: `#[allocative(skip)]` and `#[allocative(bound = "")]`.
+/// Proc macro supports two attributes: `#[allocative(skip)]` and
+/// `#[allocative(bound = "...")]`.
 ///
 /// ## `#[allocative(skip)]`
 ///
-/// `#[allocative(skip)]` can be used to skip field from traversal
-/// (for example, to skip fields which are not `Allocative`,
-/// and can be skipped because they are cheap).
+/// `#[allocative(skip)]` can be used to skip field from traversal (for example,
+/// to skip fields which are not `Allocative`, and can be skipped because they
+/// are cheap).
 ///
 /// ```
 /// use allocative::Allocative;
@@ -46,10 +47,15 @@ use crate::Visitor;
 /// }
 /// ```
 ///
-/// ## `#[allocative(bound = "")]`
+/// ## `#[allocative(bound = "...")]`
 ///
-/// `#[allocative(bound = "")]` can be used to not add `T: Allocative` bound
-/// to `Allocative` trait implementation, like this:
+/// `#[allocative(bound = "...")]` can be used to overwrite the bounds that are
+/// added to the generics of the implementation.
+///
+/// An empty string (`#[allocative(bound = "")]`) simply erases all bounds. It
+/// adds all type variables found in the type to the list of generics but with
+/// an empty bound. As an example
+///
 ///
 /// ```
 /// use std::marker::PhantomData;
@@ -62,9 +68,34 @@ use crate::Visitor;
 /// struct Baz<T> {
 ///     _marker: PhantomData<T>,
 /// }
+/// ```
 ///
-/// // So `Baz<Unsupported>` is `Allocative` even though `Unsupported` is not.
-/// let allocative: &dyn Allocative = &Baz::<Unsupported> { _marker: PhantomData };
+/// Would generate an instance
+///
+/// ```
+/// impl<T> Allocative for Baz<T> { ... }
+/// ```
+///
+/// Alternatively you can use the string to provide custom bounds. The string in
+/// this case is used *verbatim* as the bounds, which affords great flexibility,
+/// but also necessitates that all type variables must be mentioned or will be
+/// unbound (compile error). As an example we may derive a size of a `HashMap`
+/// by ignoring the hasher type.
+///
+///
+/// ```
+/// #[allocative(bound = "K: Allocative, V:Allocative, S")]
+/// struct HashMap<K, V, S = RandomState> {
+///    ...
+/// }
+/// ```
+///
+/// Which generates
+///
+/// ```
+/// impl<K: Allocative, V:Allocative, S> Allocative for HashMap<K, V, S> {
+///    ...
+/// }
 /// ```
 pub trait Allocative {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>);

--- a/allocative/src/test_derive/bounds.rs
+++ b/allocative/src/test_derive/bounds.rs
@@ -1,0 +1,24 @@
+use crate as allocative;
+use crate::Allocative;
+
+#[derive(Allocative)]
+#[allocative(bound = "K: Allocative, V:Allocative, S")]
+struct HashMap<K, V, S = std::collections::hash_map::RandomState> {
+    map: std::collections::HashMap<K, V, S>,
+}
+
+#[derive(Allocative)]
+#[allocative(bound = "S: Sized")]
+struct CanBeUnsized<S: ?Sized> {
+    #[allocative(visit = via_sized)]
+    s: Box<S>,
+}
+
+fn via_sized<S>(s: &Box<S>, visitor: &mut allocative::Visitor) {
+    visitor
+        .enter(
+            allocative::Key::new("s"),
+            std::mem::size_of_val(Box::as_ref(s)),
+        )
+        .exit()
+}

--- a/allocative/src/test_derive/mod.rs
+++ b/allocative/src/test_derive/mod.rs
@@ -10,6 +10,7 @@
 #![cfg(test)]
 #![allow(dead_code)]
 
+mod bounds;
 mod dst;
 mod skip;
 mod visit;

--- a/allocative_derive/src/derive_allocative.rs
+++ b/allocative_derive/src/derive_allocative.rs
@@ -54,10 +54,20 @@ fn impl_generics(
 ) -> syn::Result<proc_macro2::TokenStream> {
     if let Some(bound) = &attrs.bound {
         if !bound.is_empty() {
-            return Err(syn::Error::new(
-                attrs.bound.span(),
-                "non-empty bound is not implemented",
-            ));
+            use proc_macro2::{
+                Punct, Spacing, TokenStream as TokenStream2, TokenStream, TokenTree,
+            };
+            let mut verbatim_bound = TokenStream2::default();
+            verbatim_bound.extend(TokenStream2::from(TokenTree::from(Punct::new(
+                '<',
+                Spacing::Alone,
+            ))));
+            verbatim_bound.extend(bound.parse::<TokenStream>()?);
+            verbatim_bound.extend(TokenStream2::from(TokenTree::from(Punct::new(
+                '>',
+                Spacing::Alone,
+            ))));
+            return Ok(verbatim_bound);
         }
     }
 


### PR DESCRIPTION
This implements the non-empty `allocative(bound = "...")` as a simple verbatim bounds override. This is similar to how `serde` handles its `bound` annotations where the user simply gets full control to add whatever they like. The "downside" of this is that the user *must* make sure to list all type variables that are used in the type.

The upshot is that it gives a lot of flexibility to the user to also list additional constraints,(e.g. lifetimes) and it is very efficient to imlpement.

For example 

```rs
#[derive(allocative::Allocative)]
#[allocative(bound = "N: allocative::Allocative, E: allocative::Allocative, Ty")]
pub struct GraphMap<N, E, Ty> {
    nodes: IndexMap<N, Vec<(N, CompactDirection)>>,
    edges: IndexMap<(N, N), E>,
    #[allocative(skip)]
    ty: PhantomData<Ty>,
}
```

Creates

```rs
impl<N: allocative::Allocative, E: allocative::Allocative, Ty> allocative::Allocative for GraphMap<N, E, Ty> {
    ....
}
```