### PR TITLE
Added `visit_field_with` and `ident_key` convenience method and macro

### DIFF
--- a/allocative/src/lib.rs
+++ b/allocative/src/lib.rs
@@ -73,3 +73,33 @@ pub use crate::visitor::Visitor;
 pub mod __macro_refs {
     pub use ctor;
 }
+
+/// Create a `const` of type `Key` with the provided `ident` as the value and
+/// return that value. This allows the keys to be placed conveniently inline
+/// without any performance hit because unlike calling `Key::new` this is
+/// guaranteed to be evaluated at compile time.
+///
+/// The main use case is manual implementations of [`Allocative`], like so:
+///
+/// ```
+/// struct MyStruct {
+///     foo: usize,
+///     bar: Vec<()>,
+/// }
+///
+/// impl Allocative for MyStruct {
+///     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
+///         let visitor = visitor.enter_self(self);
+///         visitor.visit_field(ident_key!(foo), &self.foo);
+///         visitor.visit_field(ident_key!(bar), &self.bar);
+///         visitor.exit();
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! ident_key {
+    ($name:ident) => {{
+        const KEY: Key = Key::new(stringify!(name));
+        KEY
+    }};
+}


### PR DESCRIPTION
Adds the `ident_key` macro which expands an ident to a `const` `Key`, which is a common necessity when manually implementing instances of `Allocative`. Whereas before you had to write code like code like 

```rs 
struct TyType {
    field: ...
}

impl Allocative for MyType {
    fn visit<'a, 'b: 'a>(&self, visitor: &'a mut allocative::Visitor<'b>) {
        const KEY : Key = Key::new("field");
        let vis = visitor.enter_self(self);
        vis.visit_field(KEY, &self.field);
        vis.exit();
    }
} 
```

or

```rs
vis.visit_field({
    const KEY: Key = Key::new("field");
    KEY
}, &self.field);
```

now you can just write 

```rs
vis.visit_field(ident_key!(field), &self.field);
```

With no loss of efficiency