### PR TITLE
Correct some edge cases with Arc and Rc

### DIFF
--- a/allocative/src/impls/std/sync.rs
+++ b/allocative/src/impls/std/sync.rs
@@ -47,8 +47,10 @@ impl<T: Allocative + ?Sized> Allocative for Arc<T> {
         {
             let visitor = visitor.enter_shared(
                 PTR_NAME,
-                // TODO(nga): 8 or 16 depending on sized or unsized.
-                mem::size_of::<*const ()>(),
+                // Possibly fat pointer for size
+                mem::size_of::<*const T>(),
+                // Force thin pointer for identity, as fat pointers can have
+                // different VTable addresses attached to the same memory
                 Arc::as_ptr(self) as *const (),
             );
             if let Some(mut visitor) = visitor {
@@ -88,8 +90,10 @@ impl<T: Allocative> Allocative for Rc<T> {
         {
             let visitor = visitor.enter_shared(
                 PTR_NAME,
-                // TODO(nga): 8 or 16 depending on sized or unsized.
-                mem::size_of::<*const ()>(),
+                // Possibly fat pointer for size
+                mem::size_of::<*const T>(),
+                // Force thin pointer for identity, as fat pointers can have
+                // different VTable addresses attached to the same memory
                 Rc::as_ptr(self) as *const (),
             );
             if let Some(mut visitor) = visitor {

--- a/allocative/src/impls/std/sync_test_arc_align.src
+++ b/allocative/src/impls/std/sync_test_arc_align.src
@@ -1,0 +1,9 @@
+# @generated
+# To regenerate, run:
+# ```
+# ALLOCATIVE_REGENERATE_TESTS=1 cargo test -p allocative
+# ```
+ArcInner 64
+ArcInner;allocative::impls::std::sync::tests::CacheLine 63
+ArcInner;allocative::impls::std::sync::tests::CacheLine;0;u8 1
+alloc::sync::Arc<allocative::impls::std::sync::tests::CacheLine>;ptr 8

--- a/allocative/src/impls/triomphe_test_align.src
+++ b/allocative/src/impls/triomphe_test_align.src
@@ -1,0 +1,8 @@
+# @generated
+# To regenerate, run:
+# ```
+# ALLOCATIVE_REGENERATE_TESTS=1 cargo test -p allocative
+# ```
+allocative::impls::triomphe::ArcInnerRepr 15
+allocative::impls::triomphe::ArcInnerRepr;data;u8 1
+triomphe::arc::Arc<u8>;ptr 8

--- a/allocative/src/impls/triomphe_test_shared.src
+++ b/allocative/src/impls/triomphe_test_shared.src
@@ -6,7 +6,7 @@
 alloc::vec::Vec<triomphe::arc::Arc<alloc::string::String>> 16
 alloc::vec::Vec<triomphe::arc::Arc<alloc::string::String>>;ptr 8
 alloc::vec::Vec<triomphe::arc::Arc<alloc::string::String>>;ptr;triomphe::arc::Arc<alloc::string::String>;ptr 24
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr 8
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr;data;alloc::string::String 16
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr;data;alloc::string::String;ptr 8
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr;data;alloc::string::String;ptr;capacity;u8 100
+allocative::impls::triomphe::ArcInnerRepr 8
+allocative::impls::triomphe::ArcInnerRepr;data;alloc::string::String 16
+allocative::impls::triomphe::ArcInnerRepr;data;alloc::string::String;ptr 8
+allocative::impls::triomphe::ArcInnerRepr;data;alloc::string::String;ptr;capacity;u8 100

--- a/allocative/src/impls/triomphe_test_simple.src
+++ b/allocative/src/impls/triomphe_test_simple.src
@@ -3,8 +3,8 @@
 # ```
 # ALLOCATIVE_REGENERATE_TESTS=1 cargo test -p allocative
 # ```
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr 8
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr;data;alloc::string::String 16
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr;data;alloc::string::String;ptr 8
-allocative::impls::triomphe::<impl allocative::allocative_trait::Allocative for triomphe::arc::Arc<_>>::visit::ArcInnerRepr;data;alloc::string::String;ptr;capacity;u8 3
+allocative::impls::triomphe::ArcInnerRepr 8
+allocative::impls::triomphe::ArcInnerRepr;data;alloc::string::String 16
+allocative::impls::triomphe::ArcInnerRepr;data;alloc::string::String;ptr 8
+allocative::impls::triomphe::ArcInnerRepr;data;alloc::string::String;ptr;capacity;u8 3
 triomphe::arc::Arc<alloc::string::String>;ptr 8


### PR DESCRIPTION
- `Arc<dyn Trait>` now records pointer size correctly as 16 bytes
- `Arc<CacheLine>` / other large-alignment types no longer under-report size of ArcInner/RcInner. Now they include the padding.
- `triomphe::Arc<T>` now includes padding in the heap part for small T