### PR TITLE
Add key! macro and use it for all Key::new calls

### DIFF
--- a/allocative/src/allocative_trait.rs
+++ b/allocative/src/allocative_trait.rs
@@ -115,6 +115,7 @@ use crate::Visitor;
 /// use allocative::Allocative;
 /// use allocative::Key;
 /// use allocative::Visitor;
+/// use allocative::key;
 /// // use third_party_lib::Unsupported;
 /// # struct Unsupported<T>(T);
 /// # impl<T> Unsupported<T> {
@@ -128,10 +129,9 @@ use crate::Visitor;
 /// }
 ///
 /// fn visit_unsupported<'a, 'b>(u: &Unsupported<usize>, visitor: &'a mut Visitor<'b>) {
-///     const ELEM_KEY: Key = Key::new("elements");
 ///     let mut visitor = visitor.enter_self(u);
 ///     for element in u.iter_elems() {
-///         visitor.visit_field(ELEM_KEY, element);
+///         visitor.visit_field(key!("elements"), element);
 ///     }
 ///     visitor.exit()
 /// }

--- a/allocative/src/flamegraph.rs
+++ b/allocative/src/flamegraph.rs
@@ -500,7 +500,7 @@ mod tests {
     use crate::flamegraph::FlameGraphBuilder;
     use crate::flamegraph::Tree;
     use crate::flamegraph::Trees;
-    use crate::key::Key;
+    use crate::key;
 
     #[test]
     fn test_empty() {
@@ -522,7 +522,7 @@ mod tests {
     #[test]
     fn test_simple() {
         let mut fg = FlameGraphBuilder::default();
-        fg.root_visitor().visit_simple(Key::new("a"), 10);
+        fg.root_visitor().visit_simple(key!("a"), 10);
         let tree = fg.finish_impl();
 
         let mut expected = Trees::default();
@@ -532,7 +532,7 @@ mod tests {
         expected[expected_root].rem_size = -10;
         expected[expected_root]
             .children
-            .insert(Key::new("a"), expected_child);
+            .insert(key!("a"), expected_child);
         expected[expected_child].size = 10;
         expected[expected_child].rem_size = 10;
         let expected = Tree {
@@ -547,10 +547,10 @@ mod tests {
     fn test_unique() {
         let mut fg = FlameGraphBuilder::default();
         let mut visitor = fg.root_visitor();
-        let mut s = visitor.enter(Key::new("Struct"), 10);
-        s.visit_simple(Key::new("a"), 3);
-        let mut un = s.enter_unique(Key::new("p"), 6);
-        un.visit_simple(Key::new("x"), 13);
+        let mut s = visitor.enter(key!("Struct"), 10);
+        s.visit_simple(key!("a"), 3);
+        let mut un = s.enter_unique(key!("p"), 6);
+        un.visit_simple(key!("x"), 13);
         un.exit();
         s.exit();
         visitor.exit();
@@ -577,12 +577,12 @@ mod tests {
         let mut visitor = fg.root_visitor();
 
         for _ in 0..2 {
-            let mut s = visitor.enter(Key::new("Struct"), 10);
-            s.visit_simple(Key::new("a"), 3);
+            let mut s = visitor.enter(key!("Struct"), 10);
+            s.visit_simple(key!("a"), 3);
             {
-                let sh = s.enter_shared(Key::new("p"), 6, &p as *const i32 as *const ());
+                let sh = s.enter_shared(key!("p"), 6, &p as *const i32 as *const ());
                 if let Some(mut sh) = sh {
-                    sh.visit_simple(Key::new("Shared"), 13);
+                    sh.visit_simple(key!("Shared"), 13);
                     sh.exit();
                 }
             }
@@ -609,8 +609,8 @@ mod tests {
     fn test_inline_children_too_large() {
         let mut fg = FlameGraphBuilder::default();
         let mut visitor = fg.root_visitor();
-        let mut child_visitor = visitor.enter(Key::new("a"), 10);
-        child_visitor.visit_simple(Key::new("b"), 13);
+        let mut child_visitor = visitor.enter(key!("a"), 10);
+        child_visitor.visit_simple(key!("b"), 13);
         child_visitor.exit();
         visitor.exit();
         let output = fg.finish();
@@ -629,7 +629,7 @@ mod tests {
         b_1.add_self(10);
 
         let mut b = FlameGraph::default();
-        b.add_child(Key::new("x"), b_1);
+        b.add_child(key!("x"), b_1);
 
         a.add(b);
         assert_eq!(10, a.total_size());

--- a/allocative/src/impls/common.rs
+++ b/allocative/src/impls/common.rs
@@ -8,19 +8,20 @@
  * above-listed licenses.
  */
 
+use crate::key;
 use crate::key::Key;
 
 /// "Field" describing allocated but unused capacity (e.g. in `Vec`).
-pub(crate) const UNUSED_CAPACITY_NAME: Key = Key::new("unused_capacity");
+pub(crate) const UNUSED_CAPACITY_NAME: Key = key!("unused_capacity");
 
 /// "Field" describing all capacity (e.g. in `Vec`).
-pub(crate) const CAPACITY_NAME: Key = Key::new("capacity");
+pub(crate) const CAPACITY_NAME: Key = key!("capacity");
 
 /// Generic pointee field in types like `Box`.
-pub(crate) const PTR_NAME: Key = Key::new("ptr");
+pub(crate) const PTR_NAME: Key = key!("ptr");
 
 /// Generic name for useful data (e.g. in `Vec`).
-pub(crate) const DATA_NAME: Key = Key::new("data");
+pub(crate) const DATA_NAME: Key = key!("data");
 
-pub(crate) const KEY_NAME: Key = Key::new("key");
-pub(crate) const VALUE_NAME: Key = Key::new("value");
+pub(crate) const KEY_NAME: Key = key!("key");
+pub(crate) const VALUE_NAME: Key = key!("value");

--- a/allocative/src/impls/compact_str.rs
+++ b/allocative/src/impls/compact_str.rs
@@ -15,7 +15,7 @@ use compact_str::CompactString;
 use crate::allocative_trait::Allocative;
 use crate::impls::common::PTR_NAME;
 use crate::impls::common::UNUSED_CAPACITY_NAME;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl Allocative for CompactString {
@@ -23,7 +23,7 @@ impl Allocative for CompactString {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if self.is_heap_allocated() {
             let mut visitor = visitor.enter_unique(PTR_NAME, std::mem::size_of::<*const u8>());
-            visitor.visit_simple(Key::new("str"), self.len());
+            visitor.visit_simple(key!("str"), self.len());
             let unused_capacity = self.capacity() - self.len();
             visitor.visit_simple(UNUSED_CAPACITY_NAME, unused_capacity);
         }

--- a/allocative/src/impls/either.rs
+++ b/allocative/src/impls/either.rs
@@ -13,15 +13,15 @@
 use either::Either;
 
 use crate::allocative_trait::Allocative;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl<A: Allocative, B: Allocative> Allocative for Either<A, B> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         match self {
-            Either::Left(a) => visitor.visit_field::<A>(Key::new("Left"), a),
-            Either::Right(b) => visitor.visit_field::<B>(Key::new("Right"), b),
+            Either::Left(a) => visitor.visit_field::<A>(key!("Left"), a),
+            Either::Right(b) => visitor.visit_field::<B>(key!("Right"), b),
         }
     }
 }

--- a/allocative/src/impls/hashbrown.rs
+++ b/allocative/src/impls/hashbrown.rs
@@ -17,6 +17,7 @@ use hashbrown::HashTable;
 use crate::Allocative;
 use crate::Key;
 use crate::Visitor;
+use crate::key;
 
 const CAPACITY_NAME: Key = Key::new("capacity");
 

--- a/allocative/src/impls/indexmap.rs
+++ b/allocative/src/impls/indexmap.rs
@@ -18,7 +18,7 @@ use indexmap::IndexSet;
 use crate::allocative_trait::Allocative;
 use crate::impls::common::UNUSED_CAPACITY_NAME;
 use crate::impls::hashbrown_util::raw_table_alloc_size_for_len;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 /// Add approximate allocations for hashbrown `RawTable`.
@@ -26,8 +26,8 @@ fn add_raw_table_for_len<T>(visitor: &mut Visitor, len: usize) {
     if len != 0 {
         // We don't depend on `RawTable`, so we don't know the size of `RawTable`.
         let size_of_raw_table = mem::size_of::<usize>();
-        let mut visitor = visitor.enter_unique(Key::new("raw_table"), size_of_raw_table);
-        visitor.visit_simple(Key::new("alloc"), raw_table_alloc_size_for_len::<T>(len));
+        let mut visitor = visitor.enter_unique(key!("raw_table"), size_of_raw_table);
+        visitor.visit_simple(key!("alloc"), raw_table_alloc_size_for_len::<T>(len));
         visitor.exit();
     }
 }
@@ -36,9 +36,9 @@ impl<T: Allocative, S> Allocative for IndexSet<T, S> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         {
-            let mut visitor = visitor.enter_unique(Key::new("data"), mem::size_of::<*const ()>());
+            let mut visitor = visitor.enter_unique(key!("data"), mem::size_of::<*const ()>());
             for v in self {
-                visitor.visit_field(Key::new("value"), v);
+                visitor.visit_field(key!("value"), v);
             }
             let unused_capacity = self.capacity() - self.len();
             visitor.visit_simple(UNUSED_CAPACITY_NAME, unused_capacity * mem::size_of::<T>());
@@ -52,10 +52,10 @@ impl<K: Allocative, V: Allocative, S> Allocative for IndexMap<K, V, S> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         {
-            let mut visitor = visitor.enter_unique(Key::new("data"), mem::size_of::<*const ()>());
+            let mut visitor = visitor.enter_unique(key!("data"), mem::size_of::<*const ()>());
             for (k, v) in self {
-                visitor.visit_field(Key::new("key"), k);
-                visitor.visit_field(Key::new("value"), v);
+                visitor.visit_field(key!("key"), k);
+                visitor.visit_field(key!("value"), v);
             }
             let unused_capacity = self.capacity() - self.len();
             visitor.visit_simple(

--- a/allocative/src/impls/lock_api.rs
+++ b/allocative/src/impls/lock_api.rs
@@ -16,14 +16,14 @@ use parking_lot::lock_api::RawRwLock;
 use parking_lot::lock_api::RwLock;
 
 use crate::allocative_trait::Allocative;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl<R: RawMutex + 'static, T: Allocative> Allocative for Mutex<R, T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Some(data) = self.try_lock() {
-            visitor.visit_field(Key::new("data"), &*data);
+            visitor.visit_field(key!("data"), &*data);
         }
         visitor.exit();
     }
@@ -33,7 +33,7 @@ impl<R: RawRwLock + 'static, T: Allocative> Allocative for RwLock<R, T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Some(data) = self.try_read() {
-            visitor.visit_field(Key::new("data"), &*data);
+            visitor.visit_field(key!("data"), &*data);
         }
         visitor.exit();
     }

--- a/allocative/src/impls/relative_path.rs
+++ b/allocative/src/impls/relative_path.rs
@@ -16,7 +16,7 @@ use relative_path::RelativePathBuf;
 
 use crate::allocative_trait::Allocative;
 use crate::impls::common::PTR_NAME;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl Allocative for RelativePathBuf {
@@ -24,7 +24,7 @@ impl Allocative for RelativePathBuf {
         let mut visitor = visitor.enter_self_sized::<Self>();
         {
             let mut visitor = visitor.enter_unique(PTR_NAME, mem::size_of::<*const u8>());
-            visitor.visit_simple(Key::new("chars"), self.as_str().len());
+            visitor.visit_simple(key!("chars"), self.as_str().len());
             // TODO(nga): spare capacity.
             visitor.exit();
         }

--- a/allocative/src/impls/serde_json.rs
+++ b/allocative/src/impls/serde_json.rs
@@ -13,8 +13,8 @@
 use std::mem;
 
 use crate::Allocative;
-use crate::Key;
 use crate::Visitor;
+use crate::key;
 
 impl Allocative for serde_json::Number {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
@@ -28,10 +28,10 @@ impl Allocative for serde_json::Map<String, serde_json::Value> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         {
-            let mut visitor = visitor.enter_unique(Key::new("data"), mem::size_of::<*mut ()>());
+            let mut visitor = visitor.enter_unique(key!("data"), mem::size_of::<*mut ()>());
             for (k, v) in self.iter() {
-                visitor.visit_field(Key::new("key"), k);
-                visitor.visit_field(Key::new("value"), v);
+                visitor.visit_field(key!("key"), k);
+                visitor.visit_field(key!("value"), v);
             }
             visitor.exit();
         }
@@ -45,10 +45,10 @@ impl Allocative for serde_json::Value {
         match self {
             serde_json::Value::Null => {}
             serde_json::Value::Bool(_b) => {}
-            serde_json::Value::Number(n) => visitor.visit_field(Key::new("Number"), n),
-            serde_json::Value::String(s) => visitor.visit_field(Key::new("String"), s),
-            serde_json::Value::Array(a) => visitor.visit_field(Key::new("Array"), a),
-            serde_json::Value::Object(o) => visitor.visit_field(Key::new("Object"), o),
+            serde_json::Value::Number(n) => visitor.visit_field(key!("Number"), n),
+            serde_json::Value::String(s) => visitor.visit_field(key!("String"), s),
+            serde_json::Value::Array(a) => visitor.visit_field(key!("Array"), a),
+            serde_json::Value::Object(o) => visitor.visit_field(key!("Object"), o),
         }
         visitor.exit();
     }

--- a/allocative/src/impls/smallvec.rs
+++ b/allocative/src/impls/smallvec.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 
 use crate::allocative_trait::Allocative;
 use crate::impls::common::PTR_NAME;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl<A> Allocative for SmallVec<A>
@@ -28,13 +28,13 @@ where
         if self.spilled() {
             let mut visitor = visitor.enter_unique(PTR_NAME, std::mem::size_of::<*const A::Item>());
             for item in self {
-                visitor.visit_field(Key::new("data"), item);
+                visitor.visit_field(key!("data"), item);
             }
             // TODO(nga): spare capacity.
             visitor.exit();
         } else {
             for item in self {
-                visitor.visit_field(Key::new("data"), item);
+                visitor.visit_field(key!("data"), item);
             }
         }
         visitor.exit();

--- a/allocative/src/impls/std/mem.rs
+++ b/allocative/src/impls/std/mem.rs
@@ -11,13 +11,13 @@
 use std::mem::ManuallyDrop;
 
 use crate::Allocative;
-use crate::Key;
 use crate::Visitor;
+use crate::key;
 
 impl<T: Allocative + ?Sized> Allocative for ManuallyDrop<T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self(self);
-        visitor.visit_field::<T>(Key::new("inner"), self);
+        visitor.visit_field::<T>(key!("inner"), self);
         visitor.exit();
     }
 }

--- a/allocative/src/impls/std/sync.rs
+++ b/allocative/src/impls/std/sync.rs
@@ -30,14 +30,14 @@ use std::sync::atomic::AtomicUsize;
 
 use crate::allocative_trait::Allocative;
 use crate::impls::common::PTR_NAME;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl<T: Allocative> Allocative for RwLock<T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Ok(data) = self.try_read() {
-            visitor.visit_field(Key::new("data"), &*data);
+            visitor.visit_field(key!("data"), &*data);
         }
         visitor.exit();
     }
@@ -78,8 +78,7 @@ impl<T: Allocative + ?Sized> Allocative for Arc<T> {
             if let Some(mut visitor) = visitor {
                 {
                     let val: &T = self;
-                    let mut visitor =
-                        visitor.enter(Key::new("ArcInner"), RcBox::layout(val).size());
+                    let mut visitor = visitor.enter(key!("ArcInner"), RcBox::layout(val).size());
                     val.visit(&mut visitor);
                     visitor.exit();
                 }
@@ -117,7 +116,7 @@ impl<T: Allocative> Allocative for Rc<T> {
             if let Some(mut visitor) = visitor {
                 {
                     let val: &T = self;
-                    let mut visitor = visitor.enter(Key::new("RcInner"), RcBox::layout(val).size());
+                    let mut visitor = visitor.enter(key!("RcInner"), RcBox::layout(val).size());
                     val.visit(&mut visitor);
                     visitor.exit();
                 }
@@ -210,7 +209,7 @@ impl<T: Allocative> Allocative for Mutex<T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Ok(data) = self.try_lock() {
-            visitor.visit_field(Key::new("data"), &*data);
+            visitor.visit_field(key!("data"), &*data);
         }
         visitor.exit();
     }

--- a/allocative/src/impls/std/tuple.rs
+++ b/allocative/src/impls/std/tuple.rs
@@ -9,7 +9,7 @@
  */
 
 use crate::allocative_trait::Allocative;
-use crate::key::Key;
+use crate::key;
 use crate::visitor::Visitor;
 
 impl Allocative for () {
@@ -21,34 +21,34 @@ impl Allocative for () {
 impl<A: Allocative> Allocative for (A,) {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
-        visitor.visit_field(Key::new("0"), &self.0);
+        visitor.visit_field(key!("0"), &self.0);
     }
 }
 
 impl<A: Allocative, B: Allocative> Allocative for (A, B) {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
-        visitor.visit_field(Key::new("0"), &self.0);
-        visitor.visit_field(Key::new("1"), &self.1);
+        visitor.visit_field(key!("0"), &self.0);
+        visitor.visit_field(key!("1"), &self.1);
     }
 }
 
 impl<A: Allocative, B: Allocative, C: Allocative> Allocative for (A, B, C) {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
-        visitor.visit_field(Key::new("0"), &self.0);
-        visitor.visit_field(Key::new("1"), &self.1);
-        visitor.visit_field(Key::new("2"), &self.2);
+        visitor.visit_field(key!("0"), &self.0);
+        visitor.visit_field(key!("1"), &self.1);
+        visitor.visit_field(key!("2"), &self.2);
     }
 }
 
 impl<A: Allocative, B: Allocative, C: Allocative, D: Allocative> Allocative for (A, B, C, D) {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
-        visitor.visit_field(Key::new("0"), &self.0);
-        visitor.visit_field(Key::new("1"), &self.1);
-        visitor.visit_field(Key::new("2"), &self.2);
-        visitor.visit_field(Key::new("3"), &self.3);
+        visitor.visit_field(key!("0"), &self.0);
+        visitor.visit_field(key!("1"), &self.1);
+        visitor.visit_field(key!("2"), &self.2);
+        visitor.visit_field(key!("3"), &self.3);
     }
 }
 
@@ -57,10 +57,10 @@ impl<A: Allocative, B: Allocative, C: Allocative, D: Allocative, E: Allocative> 
 {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
-        visitor.visit_field(Key::new("0"), &self.0);
-        visitor.visit_field(Key::new("1"), &self.1);
-        visitor.visit_field(Key::new("2"), &self.2);
-        visitor.visit_field(Key::new("3"), &self.3);
-        visitor.visit_field(Key::new("4"), &self.4);
+        visitor.visit_field(key!("0"), &self.0);
+        visitor.visit_field(key!("1"), &self.1);
+        visitor.visit_field(key!("2"), &self.2);
+        visitor.visit_field(key!("3"), &self.3);
+        visitor.visit_field(key!("4"), &self.4);
     }
 }

--- a/allocative/src/impls/std/unsorted.rs
+++ b/allocative/src/impls/std/unsorted.rs
@@ -29,6 +29,7 @@ use crate::allocative_trait::Allocative;
 use crate::impls::common::DATA_NAME;
 use crate::impls::common::PTR_NAME;
 use crate::impls::common::UNUSED_CAPACITY_NAME;
+use crate::key;
 use crate::key::Key;
 use crate::visitor::Visitor;
 
@@ -40,13 +41,13 @@ impl<T: Allocative + ?Sized> Allocative for &'static T {
 
 impl Allocative for str {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
-        visitor.visit_simple(Key::new("str"), self.len());
+        visitor.visit_simple(key!("str"), self.len());
     }
 }
 
 impl Allocative for OsStr {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
-        visitor.visit_simple(Key::new("OsStr"), self.len());
+        visitor.visit_simple(key!("OsStr"), self.len());
     }
 }
 
@@ -65,8 +66,8 @@ impl<T: Allocative, E: Allocative> Allocative for Result<T, E> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         match self {
-            Ok(v) => visitor.visit_field(Key::new("Ok"), v),
-            Err(e) => visitor.visit_field(Key::new("Err"), e),
+            Ok(v) => visitor.visit_field(key!("Ok"), v),
+            Err(e) => visitor.visit_field(key!("Err"), e),
         }
     }
 }
@@ -75,7 +76,7 @@ impl<T: Allocative> Allocative for Option<T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Some(value) = self {
-            visitor.visit_field(Key::new("Some"), value);
+            visitor.visit_field(key!("Some"), value);
         }
     }
 }
@@ -128,7 +129,7 @@ impl Allocative for PathBuf {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if self.capacity() != 0 {
             let mut visitor = visitor.enter_unique(PTR_NAME, mem::size_of::<*const u8>());
-            visitor.visit_simple(Key::new("path"), self.as_os_str().len());
+            visitor.visit_simple(key!("path"), self.as_os_str().len());
             visitor.visit_simple(
                 UNUSED_CAPACITY_NAME,
                 self.capacity() - self.as_os_str().len(),

--- a/allocative/src/impls/tokio.rs
+++ b/allocative/src/impls/tokio.rs
@@ -14,14 +14,14 @@ use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 
 use crate::Allocative;
-use crate::Key;
 use crate::Visitor;
+use crate::key;
 
 impl<T: Allocative> Allocative for RwLock<T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Ok(data) = self.try_read() {
-            visitor.visit_field::<T>(Key::new("data"), &*data);
+            visitor.visit_field::<T>(key!("data"), &*data);
         }
         visitor.exit();
     }
@@ -31,7 +31,7 @@ impl<T: Allocative> Allocative for Mutex<T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self_sized::<Self>();
         if let Ok(data) = self.try_lock() {
-            visitor.visit_field::<T>(Key::new("data"), &*data);
+            visitor.visit_field::<T>(key!("data"), &*data);
         }
         visitor.exit();
     }

--- a/allocative/src/impls/triomphe.rs
+++ b/allocative/src/impls/triomphe.rs
@@ -20,15 +20,16 @@ use triomphe::HeaderWithLength;
 use triomphe::ThinArc;
 
 use crate::Allocative;
-use crate::Key;
 use crate::Visitor;
 use crate::impls::common::PTR_NAME;
+use crate::key;
+use crate::key::Key;
 
 impl<H: Allocative, T: Allocative + ?Sized> Allocative for HeaderSlice<H, T> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self(self);
-        visitor.visit_field(Key::new("header"), &self.header);
-        visitor.visit_field(Key::new("slice"), &self.slice);
+        visitor.visit_field(key!("header"), &self.header);
+        visitor.visit_field(key!("slice"), &self.slice);
         visitor.exit();
     }
 }
@@ -36,8 +37,8 @@ impl<H: Allocative, T: Allocative + ?Sized> Allocative for HeaderSlice<H, T> {
 impl<H: Allocative> Allocative for HeaderWithLength<H> {
     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
         let mut visitor = visitor.enter_self(self);
-        visitor.visit_field(Key::new("header"), &self.header);
-        visitor.visit_field(Key::new("len"), &self.length);
+        visitor.visit_field(key!("header"), &self.header);
+        visitor.visit_field(key!("len"), &self.length);
         visitor.exit();
     }
 }
@@ -67,10 +68,8 @@ impl<H: Allocative, T: Allocative> Allocative for ThinArc<H, T> {
                 {
                     let mut visitor =
                         visitor.enter(Key::for_type_name::<ThinArcInnerRepr<H>>(), size);
-                    visitor.visit_field::<HeaderSlice<HeaderWithLength<H>, [T]>>(
-                        Key::new("data"),
-                        self,
-                    );
+                    visitor
+                        .visit_field::<HeaderSlice<HeaderWithLength<H>, [T]>>(key!("data"), self);
                 }
                 visitor.exit();
             }
@@ -100,7 +99,7 @@ impl<T: Allocative + ?Sized> Allocative for Arc<T> {
                     .size();
                 {
                     let mut visitor = visitor.enter(Key::for_type_name::<ArcInnerRepr>(), size);
-                    visitor.visit_field::<T>(Key::new("data"), self);
+                    visitor.visit_field::<T>(key!("data"), self);
                     visitor.exit();
                 }
                 visitor.exit();

--- a/allocative/src/lib.rs
+++ b/allocative/src/lib.rs
@@ -79,8 +79,7 @@ pub mod __macro_refs {
     pub use ctor;
 }
 
-/// Create a `const` [`Key`] from a string literal, guaranteed to be evaluated
-/// at compile time.
+/// Create a `const` [`Key`], guaranteed to be evaluated at compile time.
 ///
 /// ```
 /// use allocative::Allocative;
@@ -103,20 +102,18 @@ pub mod __macro_refs {
 /// ```
 #[macro_export]
 macro_rules! key {
-    ($s:literal) => {{
-        const KEY: $crate::Key = $crate::Key::new($s);
-        KEY
-    }};
+    ($s:expr) => {
+        const { $crate::Key::new($s) }
+    };
 }
 
 /// Create a `const` [`Key`] from an identifier. This is a convenience wrapper
 /// around [`key!`] that stringifies the identifier.
 #[macro_export]
 macro_rules! ident_key {
-    ($name:ident) => {{
-        const KEY: $crate::Key = $crate::Key::new(stringify!($name));
-        KEY
-    }};
+    ($name:ident) => {
+        $crate::key!(stringify!($name))
+    };
 }
 
 #[test]

--- a/allocative/src/lib.rs
+++ b/allocative/src/lib.rs
@@ -79,17 +79,13 @@ pub mod __macro_refs {
     pub use ctor;
 }
 
-/// Create a `const` of type `Key` with the provided `ident` as the value and
-/// return that value. This allows the keys to be placed conveniently inline
-/// without any performance hit because unlike calling `Key::new` this is
-/// guaranteed to be evaluated at compile time.
-///
-/// The main use case is manual implementations of [`Allocative`], like so:
+/// Create a `const` [`Key`] from a string literal, guaranteed to be evaluated
+/// at compile time.
 ///
 /// ```
 /// use allocative::Allocative;
 /// use allocative::Visitor;
-/// use allocative::ident_key;
+/// use allocative::key;
 ///
 /// struct MyStruct {
 ///     foo: usize,
@@ -99,12 +95,22 @@ pub mod __macro_refs {
 /// impl Allocative for MyStruct {
 ///     fn visit<'a, 'b: 'a>(&self, visitor: &'a mut Visitor<'b>) {
 ///         let mut visitor = visitor.enter_self(self);
-///         visitor.visit_field(ident_key!(foo), &self.foo);
-///         visitor.visit_field(ident_key!(bar), &self.bar);
+///         visitor.visit_field(key!("foo"), &self.foo);
+///         visitor.visit_field(key!("bar"), &self.bar);
 ///         visitor.exit();
 ///     }
 /// }
 /// ```
+#[macro_export]
+macro_rules! key {
+    ($s:literal) => {{
+        const KEY: $crate::Key = $crate::Key::new($s);
+        KEY
+    }};
+}
+
+/// Create a `const` [`Key`] from an identifier. This is a convenience wrapper
+/// around [`key!`] that stringifies the identifier.
 #[macro_export]
 macro_rules! ident_key {
     ($name:ident) => {{
@@ -114,6 +120,7 @@ macro_rules! ident_key {
 }
 
 #[test]
-fn ident_key() {
-    assert_eq!(ident_key!(foo), Key::new("foo"));
+fn test_key() {
+    assert_eq!(key!("foo"), Key::new("foo"));
+    assert_eq!(ident_key!(foo), key!("foo"));
 }

--- a/allocative/src/test_derive/bounds.rs
+++ b/allocative/src/test_derive/bounds.rs
@@ -27,9 +27,6 @@ struct CanBeUnsized<S: ?Sized> {
 #[allow(clippy::borrowed_box)]
 fn via_sized<S>(s: &Box<S>, visitor: &mut allocative::Visitor) {
     visitor
-        .enter(
-            allocative::Key::new("s"),
-            std::mem::size_of_val(Box::as_ref(s)),
-        )
+        .enter(allocative::key!("s"), std::mem::size_of_val(Box::as_ref(s)))
         .exit()
 }


### PR DESCRIPTION
Avoid calculating the hash at runtime.